### PR TITLE
Fix libc6 apt errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,4 +15,4 @@ runs:
         echo "Runs on: ${{ inputs.os }}"
         sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
         sudo apt-get update
-        sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+        sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.5 libc6-dev=2.35-0ubuntu3.5 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04


### PR DESCRIPTION
Fixes the following errors when running the action:
```
E: Version '2.35-0ubuntu3.4' for 'libc6' was not found
E: Version '2.35-0ubuntu3.4' for 'libc6-dev' was not found