### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: "[Ubuntu] Remove GCC 13 from runner image"
-      if: (inputs.os == 'ubuntu-latest') || (inputs.os == 'ubuntu-22.04') || (inputs.os == 'default')
+      if: inputs.os == 'ubuntu-22.04'
       shell: bash
       run: |
         echo "Runs on: ${{ inputs.os }}"


### PR DESCRIPTION
ubuntu-latest has updated to 24.04 on Jan 17: https://github.com/actions/runner-images/issues/10636

And the workaround as defined does not work there, see: https://github.com/microsoft/rego-cpp/pull/170

```
Package libc6 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libc6-dev libnss-nis libcrypt1

Package libgcc-s1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package libstdc++6 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package libc6-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libc6-dev-i386 rpcsvc-proto libnsl-dev libcrypt-dev

E: Version '2.35-*' for 'libc6' was not found
E: Version '2.35-*' for 'libc6-dev' was not found
E: Version '12.3.0-*' for 'libstdc++6' was not found
E: Version '12.3.0-*' for 'libgcc-s1' was not found
```

I am not sure if the workaround is not necessary on 24.04, or needs to take a different form.